### PR TITLE
gen oneof constructor

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -856,7 +856,7 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 				g.P(fmt.Sprintf("func New%s%s (%s) *%s {", m.GoIdent.GoName, field.GoName, strings.Join(params, ","), m.GoIdent.GoName))
 				g.P(fmt.Sprintf("return &%s {", m.GoIdent.GoName))
 				g.P(fmt.Sprintf("%s: &%s {", field.Oneof.GoName, field.GoIdent.GoName))
-				g.P(fmt.Sprintf("%s: &%s{", field.GoName, ty))
+				g.P(fmt.Sprintf("%s: &%s {", field.GoName, ty))
 				for i := 0; i < len(field.Message.Fields); i++ {
 					f := field.Message.Fields[i]
 					g.P(fmt.Sprintf("%s: p%s,", f.GoName, f.GoName))

--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -850,8 +850,7 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 			if field.Message != nil {
 				params := make([]string, len(field.Message.Fields))
 				for i := 0; i < len(field.Message.Fields); i++ {
-					ty, isPtr := fieldGoType(g, f, field.Message.Fields[i])
-					params[i] = makeParam("p"+field.Message.Fields[i].GoName, ty, isPtr)
+					params[i] = makeParam(g, f, field.Message.Fields[i])
 				}
 				g.P(fmt.Sprintf("func New%s%s (%s) *%s {", m.GoIdent.GoName, field.GoName, strings.Join(params, ","), m.GoIdent.GoName))
 				g.P(fmt.Sprintf("return &%s {", m.GoIdent.GoName))
@@ -946,10 +945,11 @@ func (c trailingComment) String() string {
 	return s
 }
 
-func makeParam(name, ty string, isPtr bool) string {
-	f := "%s %s"
+func makeParam(g *protogen.GeneratedFile, f *fileInfo, field *protogen.Field) string {
+	ty, isPtr := fieldGoType(g, f, field)
+	format := "p%s %s"
 	if isPtr {
-		f = "%s *%s"
+		format = "p%s *%s"
 	}
-	return fmt.Sprintf(f, name, ty)
+	return fmt.Sprintf(format, field.GoName, ty)
 }


### PR DESCRIPTION
https://github.com/devsisters/cba-server/commit/92c53d998d701c371787233ca7f7750e6057b7e3


Oneof 로 생성된 구조체 선언이 너무 길다

``` go
// 전
map := &commonapi.MapInfo{
   Mode: &commonapi.MapInfo_Raid_{
      Raid: &commonapi.MapInfo_Raid{
         DifficultyId: 123,
      },
   },
}
// 후
map := commonapi.NewMapInfoWithRaid(123)
```

으로 만들어보자