### PR TITLE
gen oneof type method

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -823,6 +823,7 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 		ifName := oneofInterfaceName(oneof)
 		g.P("type ", ifName, " interface {")
 		g.P(ifName, "()")
+		g.P("Type() string")
 		g.P("}")
 		g.P()
 		for _, field := range oneof.Fields {
@@ -873,11 +874,13 @@ func genMessageOneofWrapperTypes(g *protogen.GeneratedFile, f *fileInfo, m *mess
 				g.P("}")
 				g.P("}")
 			}
-
 			g.P()
 		}
 		for _, field := range oneof.Fields {
 			g.P("func (*", field.GoIdent, ") ", ifName, "() {}")
+			g.P()
+
+			g.P(fmt.Sprintf("func (*%s) Type() string { return \"%s\" }", field.GoIdent.GoName, field.GoIdent.GoName))
 			g.P()
 		}
 	}


### PR DESCRIPTION
https://github.com/devsisters/cba-server/commit/29149e141281743c501cadf2fe52317d1d520c7a

oneof 의 타입을 구분하는 방법이 if item.GetItem().GetCoin() != nil {...} 같은 방법 또는 item.GetIItem().(type) 밖에 없어 추가하였다